### PR TITLE
fix: remove duplicate label

### DIFF
--- a/charts/paperless-ngx/templates/serviceHeadless.yaml
+++ b/charts/paperless-ngx/templates/serviceHeadless.yaml
@@ -8,7 +8,6 @@ spec:
   clusterIP: None
   selector:
     app.kubernetes.io/component: redis
-    app.kubernetes.io/instance: {{ .Release.Name }}
   ports:
     - port: 6379
       targetPort: 6379

--- a/charts/paperless-ngx/templates/statefulsetRedis.yaml
+++ b/charts/paperless-ngx/templates/statefulsetRedis.yaml
@@ -8,14 +8,12 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: redis
-      app.kubernetes.io/instance: {{ .Release.Name }}
   serviceName: {{ include "paperless-ngx.redisHeadlessServiceName" . }}
   replicas: 1
   template:
     metadata:
       labels:
         app.kubernetes.io/component: redis
-        app.kubernetes.io/instance: {{ .Release.Name }}
         {{- include "paperless-ngx.labels" . | nindent 8 }}
       annotations:
     spec:


### PR DESCRIPTION
Resolve Flux release failure
```
Helm install failed for release apps/paperless-ngx with chart paperless-ngx@0.1.0: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors: line 24: mapping key "app.kubernetes.io/instance" already defined at line 22
```

Label was already defined in `_helpers.tpl`. Helm CLI seems to be more lenient. It didn't validate map key duplication the same way Flux’s renderer did. Flux seems to be using a more strict YAML unmarshaller that rejects duplicated keys. 